### PR TITLE
Robots Meta noindex Tag for Search Routes

### DIFF
--- a/changes/22.feature
+++ b/changes/22.feature
@@ -1,0 +1,1 @@
+Render a `noindex` robots meta tag for search routes.

--- a/gcweb.theme
+++ b/gcweb.theme
@@ -131,6 +131,21 @@ function gcweb_page_attachments_alter(&$page) {
       'ga4_script',
     ];
   }
+
+  // add meta tag for robots on the search pages
+  $current_path = \Drupal::service('path.current')->getPath();
+    $path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($current_path);
+    if ($path_alias && strpos($path_alias,'/search/')) {
+      $metaRobots = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'robots',
+          'content' => 'noindex, nofollow, noarchive, nosnippet, noodp, noydir, noimageindex',
+        ],
+      ];
+      $page['#attached']['html_head'][] = [$metaRobots, 'robots'];
+    }
+
 }
 
 /**

--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -62,6 +62,9 @@
   <head>
     <head-placeholder token="{{ placeholder_token|raw }}">
     <title>{{ head_title|safe_join(' | ') }}</title>
+    {% if '/search/' in path('<current>') %}
+      <meta name="robots" content="noindex">
+    {% endif %}
     <css-placeholder token="{{ placeholder_token|raw }}">
     <js-placeholder token="{{ placeholder_token|raw }}">
   </head>

--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -62,9 +62,6 @@
   <head>
     <head-placeholder token="{{ placeholder_token|raw }}">
     <title>{{ head_title|safe_join(' | ') }}</title>
-    {% if '/search/' in path('<current>') %}
-      <meta name="robots" content="noindex">
-    {% endif %}
     <css-placeholder token="{{ placeholder_token|raw }}">
     <js-placeholder token="{{ placeholder_token|raw }}">
   </head>


### PR DESCRIPTION
fix(templates): robots tag;

- Add hardcoded noindex robots meta tag for search routes.